### PR TITLE
fix(uvncrepeater): avoid access denied on entrypoint script

### DIFF
--- a/docker/uvncrepeater/Dockerfile
+++ b/docker/uvncrepeater/Dockerfile
@@ -50,4 +50,4 @@ CMD ["chmod 644 /etc/uvnc/uvncrepeater.ini"]
 CMD ["chmod 777 /usr/bin/uvncrepeater_entrypoint.sh"]
 
 # esecuzione dello script di entrypoint il quale avvia il servizio
-ENTRYPOINT ["/usr/bin/uvncrepeater_entrypoint.sh"]
+ENTRYPOINT [ "/bin/sh", "/usr/bin/uvncrepeater_entrypoint.sh" ]


### PR DESCRIPTION
I had the following error 
`Error response from daemon: OCI runtime create failed: container_linux.go:380: starting container process caused: exec: "/usr/bin/uvncrepeater_entrypoint.sh": permission denied: unknown`

when executing 
`docker compose up -d`

_**System info**_
Ubuntu 18.04.6 LTS
Docker version 20.10.12, build e91ed57
Docker Compose version v2.2.3


